### PR TITLE
fix:修复547题代码变量返回错误的bug

### DIFF
--- a/problems/547.friend-circles-en.md
+++ b/problems/547.friend-circles-en.md
@@ -121,7 +121,7 @@ class FindCirclesDFS {
         numCircles++;
       }
     }
-    return countCircle;
+    return numCircles++;
   }
 
   private void dfs(int[][] M, int i, boolean[] visited, int n) {


### PR DESCRIPTION
第547题朋友圈`java`代码`DFS`那里返回的变量名写错了。