### PR TITLE
fix:修复547题变量名返回错误bug

### DIFF
--- a/problems/547.friend-circles-en.md
+++ b/problems/547.friend-circles-en.md
@@ -121,7 +121,7 @@ class FindCirclesDFS {
         numCircles++;
       }
     }
-    return numCircles++;
+    return numCircles;
   }
 
   private void dfs(int[][] M, int i, boolean[] visited, int n) {

--- a/problems/547.friend-circles-en.md
+++ b/problems/547.friend-circles-en.md
@@ -121,7 +121,7 @@ class FindCirclesDFS {
         numCircles++;
       }
     }
-    return countCircle;
+    return numCircles++;
   }
 
   private void dfs(int[][] M, int i, boolean[] visited, int n) {


### PR DESCRIPTION
= = 不好意思，刚刚貌似改错= = 