### PR TITLE
fix: boundary check

### DIFF
--- a/problems/139.word-break.md
+++ b/problems/139.word-break.md
@@ -134,7 +134,7 @@ var wordBreak = function(s, wordDict) {
   dp[0] = true;
   for (let i = 0; i < s.length + 1; i++) {
     for (let word of wordDict) {
-      if (dp[i - word.length] && word.length <= i) {
+      if (word.length <= i && dp[i - word.length]) {
           if (s.substring(i - word.length, i) === word) {
             dp[i] = true;
           }


### PR DESCRIPTION
if (word.length <= i && dp[i - word.length])