### PR TITLE
修复thinkings/tree.md 1008题的bug

### DIFF
--- a/thinkings/tree.md
+++ b/thinkings/tree.md
@@ -1403,10 +1403,10 @@ def bstFromPreorder(self, preorder: List[int]) -> TreeNode:
                 mid = i
                 break
         if mid == -1:
-            return None
-
-        root.left = dfs(start + 1, mid - 1)
-        root.right = dfs(mid, end)
+            root.left = dfs(start + 1, end) 
+        else:
+            root.left = dfs(start + 1, mid - 1)
+            root.right = dfs(mid, end)
         return root
 
     return dfs(0, len(preorder) - 1)


### PR DESCRIPTION
### 修复一个1008题中的bug
- 1. 从逻辑上讲mid==-1时，不应该返回None，后边的数都在左树上就会这样
- 2. leetcode亲测 改为提交的代码可以跑过