### PR TITLE
fix: problems/220.contains-duplicate-iii.md

### DIFF
--- a/problems/220.contains-duplicate-iii.md
+++ b/problems/220.contains-duplicate-iii.md
@@ -169,7 +169,9 @@ public:
             buck[nth] = nums[i];
             if(i >= k)
             {
-                buck.erase(nums[i - k] / mod);
+                long long pos = nums[i - k] / mod;
+                if(nums[i - k] < 0) pos--;
+                buck.erase(pos);
             }
         }
         return false;


### PR DESCRIPTION
虽然C++的代码能通过leetcode的所有测试用例，但其仍存在bug：
当擦除hashmap中的元素时，键的计算方法应该和插入时的计算方法一致。否则会错误地擦除需要的元素或者保留不需要的元素。
例如：
输入：nums = [-1,10,20,1], k = 2, t = 3
预期结果：false
实际输出：true
解释：当i = 3时, 删除了nums[i-k]/mod = 0的键，但实际上值"-1"存储在键为-1的桶中，造成i=4时的错误判断。
